### PR TITLE
Support mobile views of dokuwiki

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,5 @@
 jQuery(function() {
-  jQuery('#copypageplugin__copy').click(function(e) {
-    e.preventDefault();
+  var copyThisPage = function() {
     var oldId = JSINFO.id;
     while (true) {
       var newId = prompt(LANG.plugins.copypage.enter_page_id, oldId);
@@ -16,5 +15,29 @@ jQuery(function() {
       }
       break;
     }
+  };
+
+  // Handle desktop menu
+  jQuery('#copypageplugin__copy').click(function(e) {
+    e.preventDefault();
+    copyThisPage();
   });
+
+  // Add a menu item to the "Page Tools" group of the mobile menu
+  jQuery('select.quickselect optgroup:nth-of-type(1)').append(
+    jQuery('<option value="copypage">').text(jQuery('#copypageplugin__copy').text()));
+
+  // Handle mobile menu
+  jQuery('select.quickselect')
+    .unbind('change')  // Remove dokuwiki's default handler to override its behavior
+    .change(function(e) {
+      if (e.target.value != 'copypage') {
+        // do the default action
+        e.target.form.submit();
+        return;
+      }
+
+      e.target.value = '';  // Reset selection to enable re-select when a prompt is canceled
+      copyThisPage();
+    });
 });


### PR DESCRIPTION
As there is no extension point in mobile menu, this plugin support mobile views by dirty hacks. This may break dokuwiki itself or other plugins in the future.

This PR will fix #3.

![2015-11-05 19 56 39](https://cloud.githubusercontent.com/assets/532251/10966555/b3b58a22-83f7-11e5-96a8-b49980b39f60.png)